### PR TITLE
Move from nginx to caddy

### DIFF
--- a/bitwarden/tasks/main.yml
+++ b/bitwarden/tasks/main.yml
@@ -1,4 +1,3 @@
-
 - name: Check bitwarden env
   stat:
     path: "/data/bitwarden/.env"
@@ -38,9 +37,14 @@
       - "/data/bitwarden/:/data/"
     env_file: "/data/bitwarden/.env"
 
-- name: Setup bitwarden nginx conf
+- name: Setup caddy for bitwarden
   include_role:
-    name: nginx
+    name: caddy
   vars:
-    hostname: "vault.{{ domain }}"
-    nginx_template_file: "vault"
+    caddyfile_marker: "# {mark} ANSIBLE Bitwarden"
+    caddyfile_block: |
+      vault.{{ domain }} {
+        reverse_proxy localhost:3011
+        reverse_proxy /notifications/hub localhost:3012
+        reverse_proxy /notifications/hub/negotiate localhost:3011
+      }

--- a/bitwarden/templates/vault.j2
+++ b/bitwarden/templates/vault.j2
@@ -1,3 +1,4 @@
+# [DEPRECATED] moved to caddy
 server {
   listen 80;
   listen [::]:80;

--- a/caddy/defaults/main.yml
+++ b/caddy/defaults/main.yml
@@ -1,0 +1,9 @@
+domain: aeoly.us
+caddyfile_marker: "# {mark} ANSIBLE Default"
+# TODO: remove staging
+caddyfile_block: |
+  {{ domain }} {
+    reverse_proxy https://aeolyus.github.io {
+      header_up Host aeolyus.github.io
+    }
+  }

--- a/caddy/handlers/main.yml
+++ b/caddy/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Reload caddy config
+  command: docker exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/caddy/meta/main.yml
+++ b/caddy/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: docker

--- a/caddy/tasks/main.yml
+++ b/caddy/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Check if Caddyfile exists
+  stat:
+    path: "/data/caddy/Caddyfile"
+  register: caddyfile_check
+
+- name: Create caddy directory
+  file:
+    path: "/data/caddy/"
+    state: directory
+  when: not caddyfile_check.stat.exists
+
+- name: Create Caddyfile
+  file:
+    path: "/data/caddy/Caddyfile"
+    state: touch
+  when: not caddyfile_check.stat.exists
+
+- name: Setup firewall
+  include_role:
+    role: firewalld
+  vars:
+    firewalld_services: ["http", "https"]
+
+- name: Caddy container present
+  docker_container:
+    name: caddy
+    image: caddy
+    restart_policy: unless-stopped
+    network_mode: host
+    volumes:
+      - "/data/caddy/Caddyfile:/etc/caddy/Caddyfile"
+      - "/data/caddy/caddy_data:/data"
+
+- name: Setup Caddyfile
+  blockinfile:
+    path: "/data/caddy/Caddyfile"
+    marker: "{{ caddyfile_marker }}"
+    block: "{{ caddyfile_block }}"
+    create: yes
+  register: caddy_config
+
+- name: Reload caddy config
+  command: docker restart caddy
+  when: caddy_config.changed

--- a/grafana/tasks/dashboards.yml
+++ b/grafana/tasks/dashboards.yml
@@ -18,13 +18,20 @@
     src: "home.json"
     dest: "/data/grafana/dashboards/home.json"
 
+- name: Check domain certificate
+  stat:
+    path: "/data/grafana/dashboards/nginx.json"
+  register: grafana_nginx_dashboard
+
 - name: Setup nginx dashboard
   get_url:
     url: "https://git.io/JvSCB"
     dest: "/data/grafana/dashboards/nginx.json"
+  when: not grafana_nginx_dashboard.stat.exists
 
 - name: Replace ${DS_PROMETHEUS} with prometheus in nginx dashboard
   replace:
     path: "/data/grafana/dashboards/nginx.json"
     regexp: "\\${DS_PROMETHEUS}"
     replace: "prometheus"
+  when: not grafana_nginx_dashboard.stat.exists

--- a/grafana/tasks/main.yml
+++ b/grafana/tasks/main.yml
@@ -24,9 +24,12 @@
     - Add prometheus datasource
     - Set preferred home dashboard
 
-- name: Setup grafana nginx conf
+- name: Setup caddy for grafana
   include_role:
-    name: nginx
+    name: caddy
   vars:
-    hostname: "monitor.{{ domain }}"
-    nginx_template_file: "monitor"
+    caddyfile_marker: "# {mark} ANSIBLE Grafana"
+    caddyfile_block: |
+      monitor.{{ domain }} {
+        reverse_proxy localhost:3000
+      }

--- a/grafana/templates/monitor.j2
+++ b/grafana/templates/monitor.j2
@@ -1,3 +1,4 @@
+# [DEPRECATED] moved to caddy
 server {
   listen 80 ;
   listen [::]:80 ;

--- a/nginx/tasks/main.yml
+++ b/nginx/tasks/main.yml
@@ -11,9 +11,10 @@
   vars:
     firewalld_services: ["http", "https"]
 
-- name: Get letsencrypt certs
-  include_role:
-    role: letsencrypt
+# [DEPRECATED] moved to caddy
+# - name: Get letsencrypt certs
+#   include_role:
+#     role: letsencrypt
 
 - name: Remove default file
   file:
@@ -26,18 +27,19 @@
     dest: "/etc/nginx/nginx.conf"
   register: nginx_conf
 
-- name: Check nginx site configuration
-  template:
-    src: "{{ nginx_template_file }}.j2"
-    dest: "/etc/nginx/sites-available/{{ hostname }}"
-  register: nginx_template
+# [DEPRECATED] moved to caddy
+# - name: Check nginx site configuration
+#   template:
+#     src: "{{ nginx_template_file }}.j2"
+#     dest: "/etc/nginx/sites-available/{{ hostname }}"
+#   register: nginx_template
 
-- name: Ensure nginx site symlink
-  file:
-    src: "/etc/nginx/sites-available/{{ hostname }}"
-    dest: "/etc/nginx/sites-enabled/{{ hostname }}"
-    state: link
-  register: nginx_symlink
+# - name: Ensure nginx site symlink
+#   file:
+#     src: "/etc/nginx/sites-available/{{ hostname }}"
+#     dest: "/etc/nginx/sites-enabled/{{ hostname }}"
+#     state: link
+#   register: nginx_symlink
 
 - name: Ensure nginx stream configuration
   block:
@@ -56,7 +58,5 @@
     state: restarted
     enabled: yes
   when: >
-    nginx_template.changed or
-    nginx_symlink.changed or
     nginx_stream is defined and nginx_stream.changed or
     nginx_conf.changed

--- a/nginx/templates/default.j2
+++ b/nginx/templates/default.j2
@@ -1,3 +1,4 @@
+# [DEPRECATED] moved to caddy
 limit_req_zone $binary_remote_addr zone=http:10m rate=100r/s;
 
 server {

--- a/pihole/tasks/main.yml
+++ b/pihole/tasks/main.yml
@@ -27,12 +27,27 @@
     - Set pihole password
     - Print pihole password
 
-- name: Setup pihole nginx conf
+- name: Setup caddy for pihole
+  include_role:
+    name: caddy
+  vars:
+    caddyfile_marker: "# {mark} ANSIBLE Pihole"
+    caddyfile_block: |
+      dns.{{ domain }} {
+        reverse_proxy localhost:31415
+      }
+
+- name: Wait for DNS cert before setting DoT
+  wait_for:
+    path: "/data/caddy/caddy_data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/dns.{{ domain }}/dns.{{ domain }}.crt"
+
+- name: Setup pihole DoT nginx stream conf
   include_role:
     name: nginx
   vars:
     hostname: "dns.{{ domain }}"
-    nginx_template_file: "dns"
+    # [DEPRECATED] moved to caddy
+    # nginx_template_file: "dns"
     nginx_stream_file: "dns-over-tls"
     firewalld_services: ["dns"]
     firewalld_ports: ["853/tcp"]

--- a/pihole/templates/dns-over-tls.j2
+++ b/pihole/templates/dns-over-tls.j2
@@ -4,9 +4,8 @@ upstream dns-servers {
 
 server {
   listen 853 ssl;
-  ssl_certificate /etc/letsencrypt/live/dns.{{ domain }}/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/dns.{{ domain }}/privkey.pem;
-  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+  ssl_certificate /data/caddy/caddy_data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/dns.{{ domain }}/dns.{{ domain }}.crt;
+  ssl_certificate_key /data/caddy/caddy_data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/dns.{{ domain }}/dns.{{ domain }}.key;
   ssl_protocols        TLSv1.2 TLSv1.3;
   ssl_ciphers          HIGH:!aNULL:!MD5;
   ssl_handshake_timeout    10s;

--- a/pihole/templates/dns.j2
+++ b/pihole/templates/dns.j2
@@ -1,3 +1,4 @@
+# [DEPRECATED] moved to caddy
 server {
   listen 80;
   listen [::]:80;


### PR DESCRIPTION
- pihole DoT still requires TCP streams which are not yet implemented at the time of writing by caddy so nginx the config file for that is kept